### PR TITLE
Test if collected calls are actually functions, Code Contracts style

### DIFF
--- a/src/collectcalls.joelpurra.js
+++ b/src/collectcalls.joelpurra.js
@@ -15,6 +15,38 @@ var JoelPurra = JoelPurra || {};
 {
 	"use strict";
 
+	// Code Contract style subset
+	function ContractError(msg) {
+		this.name = "ContractError";
+		var defaultMessage = "A contract was broken.";
+		this.msg = defaultMessage + (msg !== undefined ? " " + msg : "");
+	}
+	ContractError.prototype = new Error();
+	ContractError.prototype.constructor = ContractError;
+
+	var Contract = {
+		// Private functions
+		inner:
+		{
+			 isFunction: function (fnc)
+			{
+				return (typeof (fnc) === 'function');
+			}
+		},
+		// Public functions
+		Fail: function (msg)
+		{
+			throw new ContractError(msg);
+		},
+		RequireFunction: function (fnc)
+		{
+			if (!Contract.inner.isFunction(fnc))
+			{
+				Contract.Fail("Not a function: " + fnc + ".");
+			}
+		}
+	};
+
 	// Public CollectCalls functions
 	namespace.CollectCalls = function (queue, ready)
 	{
@@ -33,6 +65,8 @@ var JoelPurra = JoelPurra || {};
 
 	namespace.CollectCalls.prototype.push = function (fnc)
 	{
+		Contract.RequireFunction(fnc);
+
 		this.queue.push(fnc);
 		this.handleQueue();
 	};
@@ -42,6 +76,8 @@ var JoelPurra = JoelPurra || {};
 	{
 		try
 		{
+			Contract.RequireFunction(fnc);
+
 			fnc.call(null);
 		}
 		catch (handleOneError)

--- a/test/basic.js
+++ b/test/basic.js
@@ -229,25 +229,25 @@
 			strictEqual(counter, 0);
 
 			result.push(fncIncrement);
-			
+
 			strictEqual(queue.length, 2);
 			strictEqual(result.queue.length, 2);
 			strictEqual(counter, 0);
 
 			result.join();
-			
+
 			strictEqual(queue.length, 2);
 			strictEqual(result.queue.length, 0);
 			strictEqual(counter, 2);
 
 			queue.push(fncIncrement);
-			
+
 			strictEqual(queue.length, 3);
 			strictEqual(result.queue.length, 0);
 			strictEqual(counter, 2);
 
 			result.push(fncIncrement);
-			
+
 			strictEqual(queue.length, 3);
 			strictEqual(result.queue.length, 0);
 			strictEqual(counter, 3);
@@ -307,7 +307,7 @@
 			strictEqual(counter, 6);
 		});
 
-		test("Can add non-functions", 10, function ()
+		test("Can add non-functions", 12, function ()
 		{
 			var counter = 0;
 
@@ -333,10 +333,10 @@
 			strictEqual(counter, 0);
 
 			result.push(fncIncrement);
-			result.push(notAFunction);
+			raises(function () { result.push(notAFunction) }, Error, "Did not get expected ContractError");
 			result.push(fncIncrement);
 
-			strictEqual(result.queue.length, 6);
+			strictEqual(result.queue.length, 5);
 			strictEqual(counter, 0);
 
 			result.join();
@@ -345,7 +345,7 @@
 			strictEqual(counter, 4);
 
 			result.push(fncIncrement);
-			result.push(notAFunction);
+			raises(function () { result.push(notAFunction) }, Error, "Did not get expected ContractError");
 			result.push(fncIncrement);
 
 			strictEqual(result.queue.length, 0);


### PR DESCRIPTION
In the case anyone tries to `.push(...)` a non-function, it will be caught and an error will be thrown.

Since the invocation is already `try-catch`-wrapped, it only makes a difference when pushing after the queue has been wrapped. This is inconsistent behavior and might be confusing.

Feedback please.
